### PR TITLE
[IMP] l10n_es: Renombrado del código de los códigos de impuestos

### DIFF
--- a/l10n_es/fiscal_templates_common.xml
+++ b/l10n_es/fiscal_templates_common.xml
@@ -134,6 +134,11 @@
             <field name="chart_template_id" ref="account_chart_template_common"/>
         </record>
 
+        <record id="fp_rnrisp" model="account.fiscal.position.template">
+            <field name="name">Régimen Nacional Revendedor con Inversión del sujeto pasivo</field>
+            <field name="chart_template_id" ref="account_chart_template_common"/>
+        </record>
+
         <!-- ************************************************************* -->
         <!-- Fiscal Position Tax Templates -->
         <!-- ************************************************************* -->
@@ -2552,6 +2557,13 @@
         <record id="fptt_ispn_s_iva21s" model="account.fiscal.position.tax.template">
             <field name="position_id" ref="fp_ispn"/>
             <field name="tax_src_id" ref="account_tax_template_s_iva21s"/>
+            <field name="tax_dest_id" ref="account_tax_template_s_iva0_isp"/>
+        </record>
+
+        <!-- Revendedor inversion sujeto pasivo -->
+        <record id="fptt_rnrisp_s_iva21isp" model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_rnrisp"/>
+            <field name="tax_src_id" ref="account_tax_template_s_iva21isp"/>
             <field name="tax_dest_id" ref="account_tax_template_s_iva0_isp"/>
         </record>
 

--- a/l10n_es/migrations/8.0.5.0/pre-rename.py
+++ b/l10n_es/migrations/8.0.5.0/pre-rename.py
@@ -4,6 +4,8 @@
 #    OpenERP, Open Source Management Solution
 #    Copyright (C) 2015 Serv. Tecnol. Avanz. (<http://www.serviciosbaeza.com>)
 #                       Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
+#                       FactorLibre (<http://factorlibre.com>)
+#                       Hugo santos <hugo.santos@factorlibre.com>
 #
 #    This program is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU Affero General Public License as published
@@ -29,7 +31,250 @@ def rename_fiscal_positions(cr):
         """)
 
 
+def rename_tax_codes(cr):
+    tax_code_mapping = [
+        # Régimen general
+        {'previous_code': '[01]', 'code': 'RGIDC4'},
+        {'previous_code': '[04]', 'code': 'RGIDC10'},
+        {'previous_code': '[07]', 'code': 'RGIDC21'},
+        # IVA devengado. Cuota
+        {'previous_code': '--',
+         'previous_name': 'IVA devengado. Base imponible', 'code': 'IDBI'},
+        {'previous_code': '[21]', 'code': 'ITDC'},
+        {'previous_code': '[03]', 'code': 'RGIDC4'},
+        {'previous_code': '[06]', 'code': 'RGIDC10'},
+        {'previous_code': '[09]', 'code': 'RGIDC21'},
+        # Adquisiciones intracomunitarias
+        {'previous_code': '[20]', 'code': 'AIDBYSC'},
+        # IVA deducible. Base Imponible
+        {'previous_code': '--',
+         'previous_name': 'IVA deducible. Base imponible', 'code': 'ITADC'},
+        {'previous_code': '--',
+         'previous_name': 'Base de compensaciones Régimen Especial A., G. y'
+         ' P. 12%', 'code': 'CREAGYP12'},
+        # Base operaciones interiores corrientes
+        {'previous_code': '[22]', 'code': 'SOICC'},
+        {'previous_code': '--',
+         'previous_name': 'Base operaciones interiores corrientes (4%)',
+         'code': 'SOICC4'},
+        {'previous_code': '--',
+         'previous_name': 'Base operaciones interiores corrientes (10%)',
+         'code': 'SOICC10'},
+        {'previous_code': '--',
+         'previous_name': 'Base operaciones interiores corrientes (21%)',
+         'code': 'SOICC21'},
+        # Base operaciones interiores bienes de inversión
+        {'previous_code': '[24]', 'code': 'SOIBIC'},
+        {'previous_code': '--',
+         'previous_name': 'Base operaciones interiores bienes inversión (4%)',
+         'code': 'SOIBIC4'},
+        {'previous_code': '--',
+         'previous_name': 'Base operaciones interiores bienes inversión (10%)',
+         'code': 'SOIBIC10'},
+        {'previous_code': '--',
+         'previous_name': 'Base operaciones interiores bienes inversión (21%)',
+         'code': 'SOIBIC21'},
+        # Base importaciones de bienes corrientes
+        {'previous_code': '[26]', 'code': 'DIBCC'},
+        {'previous_code': '--',
+         'previous_name': 'Base importaciones bienes y servicios corrientes'
+         ' (4%)', 'code': 'DIBYSCC4'},
+        {'previous_code': '--',
+         'previous_name': 'Base importaciones bienes y servicios corrientes'
+         ' (10%)', 'code': 'DIBYSCC10'},
+        {'previous_code': '--',
+         'previous_name': 'Base importaciones bienes y servicios corrientes'
+         ' (21%)', 'code': 'DIBYSCC21'},
+        # Base importaciones de bienes de inversión
+        {'previous_code': '[28]', 'code': 'DIBIC'},
+        {'previous_code': '--',
+         'previous_name': 'Base importaciones bienes inversión (4%)',
+         'code': 'DIBIC4'},
+        {'previous_code': '--',
+         'previous_name': 'Base importaciones bienes inversión (10%)',
+         'code': 'DIBIC10'},
+        {'previous_code': '--',
+         'previous_name': 'Base importaciones bienes inversión (21%)',
+         'code': 'DIBIC21'},
+        # Adquisiciones intracomunitarias de bienes corrientes
+        {'previous_code': '[30]', 'code': 'AIBYSCC'},
+        {'previous_code': '--',
+         'previous_name': 'Base adquisiciones intracomunitarias bienes y'
+         ' serv. corr. (4%)', 'code': 'AIBYSCC4'},
+        {'previous_code': '--',
+         'previous_name': 'Base adquisiciones intracomunitarias bienes y'
+         ' serv. corr. (10%)', 'code': 'AIBYSCC10'},
+        {'previous_code': '--',
+         'previous_name': 'Base adquisiciones intracomunitarias bienes y'
+         ' serv. corr. (21%)', 'code': 'AIBYSCC21'},
+        # Adquisiciones intracomunitarias de bienes de inversión
+        {'previous_code': '[32]', 'code': 'AIBIC'},
+        {'previous_code': '--',
+         'previous_name': 'Base adquisiciones intracomunitarias bienes'
+         ' inversión (4%)', 'code': 'AIBIC4'},
+        {'previous_code': '--',
+         'previous_name': 'Base adquisiciones intracomunitarias bienes'
+         ' inversión (10%)', 'code': 'AIBIC10'},
+        {'previous_code': '--',
+         'previous_name': 'Base adquisiciones intracomunitarias bienes'
+         ' inversión (21%)', 'code': 'AIBIC21'},
+        # Base recargo de equivalencia
+        {'previous_code': '--',
+         'previous_name': 'Recargo equivalencia ded. Base imponible 0.5%',
+         'code': 'REDBI05'},
+        {'previous_code': '--',
+         'previous_name': 'Recargo equivalencia ded. Base imponible 1.4%',
+         'code': 'REDBI014'},
+        {'previous_code': '--',
+         'previous_name': 'Recargo equivalencia ded. Base imponible 5.2%',
+         'code': 'REDBI52'},
+        # Iva deducible cuotas
+        {'previous_code': '[37]', 'code': 'ITDC'},
+        {'previous_code': '34', 'code': 'CREAGYPBI12'},
+        # Cuotas operaciones interiores corrientes
+        {'previous_code': '[23]', 'code': 'OICBI'},
+        {'previous_code': '--',
+         'previous_name': 'Cuotas soportadas operaciones interiores corrientes'
+         ' (4%)', 'code': 'OICBI4'},
+        {'previous_code': '--',
+         'previous_name': 'Cuotas soportadas operaciones interiores corrientes'
+         ' (10%)', 'code': 'OICBI10'},
+        {'previous_code': '--',
+         'previous_name': 'Cuotas soportadas operaciones interiores corrientes'
+         ' (21%)', 'code': 'OICBI21'},
+        # Cuotas operaciones interiores con bienes de inversión
+        {'previous_code': '[25]', 'code': 'OIBIBI'},
+        {'previous_code': '--',
+         'previous_name': 'Cuotas soportadas operaciones interiores bienes'
+         ' inversión (4%)', 'code': 'OIBIBI4'},
+        {'previous_code': '--',
+         'previous_name': 'Cuotas soportadas operaciones interiores bienes'
+         ' inversión (10%)', 'code': 'OIBIBI10'},
+        {'previous_code': '--',
+         'previous_name': 'Cuotas soportadas operaciones interiores bienes'
+         ' inversión (21%)', 'code': 'OIBIBI21'},
+        # Cuotas devengadas en importaciones de bienes y serv. corr.
+        {'previous_code': '[27]', 'code': 'IBCBI'},
+        {'previous_code': '--',
+         'previous_name': 'Cuotas devengadas importaciones bienes y serv.'
+         ' corr. (4%)', 'code': 'IBYSCBI4'},
+        {'previous_code': '--',
+         'previous_name': 'Cuotas devengadas importaciones bienes y serv.'
+         ' corr. (10%)', 'code': 'IBYSCBI10'},
+        {'previous_code': '--',
+         'previous_name': 'Cuotas devengadas importaciones bienes y serv.'
+         ' corr. (21%)', 'code': 'IBYSCBI21'},
+        # Cuotas devengadas en importaciones de bienes de inversión
+        {'previous_code': '[29]', 'code': 'IBIBI'},
+        {'previous_code': '--',
+         'previous_name': 'Cuotas devengadas importaciones bienes inversión'
+         ' (4%)', 'code': 'IBIBI4'},
+        {'previous_code': '--',
+         'previous_name': 'Cuotas devengadas importaciones bienes inversión'
+         ' (10%)', 'code': 'IBIBI10'},
+        {'previous_code': '--',
+         'previous_name': 'Cuotas devengadas importaciones bienes inversión'
+         ' (21%)', 'code': 'IBIBI21'},
+        # Adquisiciones intracomunitarias de bienes corrientes
+        {'previous_code': '[31]', 'code': 'AIBYSCBI'},
+        {'previous_code': '--',
+         'previous_name': 'En adquisiciones intracomunitarias bienes y serv.'
+         ' corr. (4%)', 'code': 'AIBYSCBI4'},
+        {'previous_code': '--',
+         'previous_name': 'En adquisiciones intracomunitarias bienes y serv.'
+         ' corr. (10%)', 'code': 'AIBYSCBI10'},
+        {'previous_code': '--',
+         'previous_name': 'En adquisiciones intracomunitarias bienes y serv.'
+         ' corr. (21%)', 'code': 'AIBYSCBI21'},
+        # Adquisiciones intracomunitarias bienes de inversión
+        {'previous_code': '[33]', 'code': 'AIBIBI'},
+        {'previous_code': '--',
+         'previous_name': 'En adquisiciones intracomunitarias bienes inversión'
+         ' (4%)', 'code': 'AIBIBI4'},
+        {'previous_code': '--',
+         'previous_name': 'En adquisiciones intracomunitarias bienes inversión'
+         ' (10%)', 'code': 'AIBIBI10'},
+        {'previous_code': '--',
+         'previous_name': 'En adquisiciones intracomunitarias bienes inversión'
+         ' (21%)', 'code': 'AIBIBI21'},
+        # Otros códigos de impuestos
+        {'previous_code': '[42]', 'code': 'EIDBYS'},
+        {'previous_code': '[43]', 'code': 'EYOA'},
+        # Recargo equivalencia Cuota
+        {'previous_code': '[12]',
+         'previous_name': 'Recargo equivalencia. Cuota 0.5%',
+         'code': 'REC05'},
+        {'previous_code': '[15]',
+         'previous_name': 'Recargo equivalencia. Cuota 1.4%',
+         'code': 'REC014'},
+        {'previous_code': '[18]',
+         'previous_name': 'Recargo equivalencia. Cuota 5.2%',
+         'code': 'REC52'},
+        # Recargo equivalencia ded. Cuota
+        {'previous_code': '[12]',
+         'previous_name': 'Recargo equivalencia ded. Cuota 0.5%',
+         'code': 'REDC05'},
+        {'previous_code': '[15]',
+         'previous_name': 'Recargo equivalencia ded. Cuota 1.4%',
+         'code': 'REDC014'},
+        {'previous_code': '[18]',
+         'previous_name': 'Recargo equivalencia ded. Cuota 5.2%',
+         'code': 'REDC52'},
+        # Recargo equivalencia base imponible
+        {'previous_code': '[10]', 'code': 'REBI05'},
+        {'previous_code': '[13]', 'code': 'REBI014'},
+        {'previous_code': '[16]', 'code': 'REBI52'},
+        # IRPF Retenciones a cuenta
+        {'previous_code': 'B.IRPF AC', 'code': 'IRACBI'},
+        {'previous_code': 'B.IRPF1 AC', 'code': 'IRACBI1'},
+        {'previous_code': 'B.IRPF2 AC', 'code': 'IRACBI2'},
+        {'previous_code': 'B.IRPF7 AC', 'code': 'IRACBI7'},
+        {'previous_code': 'B.IRPF9 AC', 'code': 'IRACBI9'},
+        {'previous_code': 'B.IRPF15 AC', 'code': 'IRACBI15'},
+        {'previous_code': 'B.IRPF20 AC', 'code': 'IRACBI20'},
+        {'previous_code': 'B.IRPF21 AC', 'code': 'IRACBI21'},
+        # IRPF total retenciones a cuenta
+        {'previous_code': 'IRPF AC', 'code': 'ITRACC'},
+        {'previous_code': 'IRPF1 AC', 'code': 'IRACC1'},
+        {'previous_code': 'IRPF2 AC', 'code': 'IRACC2'},
+        {'previous_code': 'IRPF7 AC', 'code': 'IRACC7'},
+        {'previous_code': 'IRPF9 AC', 'code': 'IRACC9'},
+        {'previous_code': 'IRPF15 AC', 'code': 'IRACC15'},
+        {'previous_code': 'IRPF20 AC', 'code': 'IRACC20'},
+        {'previous_code': 'IRPF21 AC', 'code': 'IRACC21'},
+        # IRPF retenciones practicadas. base imponible
+        {'previous_code': 'B.IRPF', 'code': 'IRPBI'},
+        {'previous_code': 'B.IRPF1', 'code': 'IRPBI1'},
+        {'previous_code': 'B.IRPF2', 'code': 'IRPBI2'},
+        {'previous_code': 'B.IRPF7', 'code': 'IRPBI7'},
+        {'previous_code': 'B.IRPF9', 'code': 'IRPBI9'},
+        {'previous_code': 'B.IRPF15', 'code': 'IRPBI15'},
+        {'previous_code': 'B.IRPF20', 'code': 'IRPBI20'},
+        {'previous_code': 'B.IRPF21', 'code': 'IRPBI21'},
+        # IRPF retenciones practicadas. total cuota
+        {'previous_code': 'IRPF', 'code': 'ITRPC'},
+        {'previous_code': 'IRPF1', 'code': 'IRPC1'},
+        {'previous_code': 'IRPF2', 'code': 'IRPC2'},
+        {'previous_code': 'IRPF7', 'code': 'IRPC7'},
+        {'previous_code': 'IRPF9', 'code': 'IRPC9'},
+        {'previous_code': 'IRPF15', 'code': 'IRPC15'},
+        {'previous_code': 'IRPF20', 'code': 'IRPC20'},
+        {'previous_code': 'IRPF21', 'code': 'IRPC21'}
+    ]
+
+    for mapping in tax_code_mapping:
+        sql = """
+        UPDATE account_tax_code
+        SET code='%s'
+        WHERE code='%s'""" % (mapping['code'], mapping['previous_code'])
+
+        if mapping.get('previous_name'):
+            sql = "%s AND name='%s'" % (sql, mapping['previous_name'])
+        cr.execute(sql)
+
+
 def migrate(cr, version):
     if not version:
         return
     rename_fiscal_positions(cr)
+    rename_tax_codes(cr)

--- a/l10n_es/tax_codes_common.xml
+++ b/l10n_es/tax_codes_common.xml
@@ -871,7 +871,7 @@
     </record>
     <record id="account_tax_code_template_IRPF_RET_PRA_TRA_21_BI_E" model="account.tax.code.template">
       <field name="parent_id" ref="account_tax_code_template_IRPBI"/>
-      <field name="code">IRPT21BIE</field>
+      <field name="code">IRPTBIE</field>
       <field name="name">[05] IRPF retenciones practicadas a trabajadores. Base imponible (en especie)</field>
       <field name="sign">1.0</field>
     </record>

--- a/l10n_es/taxes_common.xml
+++ b/l10n_es/taxes_common.xml
@@ -1183,15 +1183,19 @@
           <field name="type">percent</field>
         </record>
         <record id="account_tax_template_p_irpf18" model="account.tax.template">
+          <field name="ref_base_code_id" ref="account_tax_code_template_IRPBI18"/>
           <field name="ref_base_sign" eval="-1.0"/>
           <field name="description">P_IRPF18</field>
           <field name="type_tax_use">purchase</field>
           <field name="account_paid_id" ref="pgc_4751"/>
           <field name="base_sign" eval="1.0"/>
+          <field name="base_code_id" ref="account_tax_code_template_IRPBI18"/>
           <field name="ref_tax_sign" eval="-1.0"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_IRPC18"/>
           <field name="name">Retenciones IRPF 18%</field>
           <field name="account_collected_id" ref="pgc_4751"/>
           <field name="chart_template_id" ref="account_chart_template_common"/>
+          <field name="tax_code_id" ref="account_tax_code_template_IRPC18"/>
           <field name="amount" eval="-0.18"/>
           <field name="tax_sign" eval="1.0"/>
           <field name="type">percent</field>
@@ -1215,29 +1219,37 @@
           <field name="type">percent</field>
         </record>
         <record id="account_tax_template_p_irpf7" model="account.tax.template">
+          <field name="ref_base_code_id" ref="account_tax_code_template_IRPBI7"/>
           <field name="ref_base_sign" eval="-1.0"/>
           <field name="description">P_IRPF7</field>
           <field name="type_tax_use">purchase</field>
           <field name="account_paid_id" ref="pgc_4751"/>
           <field name="base_sign" eval="1.0"/>
+          <field name="base_code_id" ref="account_tax_code_template_IRPBI7"/>
           <field name="ref_tax_sign" eval="-1.0"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_IRPC7"/>
           <field name="name">Retenciones IRPF 7%</field>
           <field name="account_collected_id" ref="pgc_4751"/>
           <field name="chart_template_id" ref="account_chart_template_common"/>
+          <field name="tax_code_id" ref="account_tax_code_template_IRPC7"/>
           <field name="amount" eval="-0.07"/>
           <field name="tax_sign" eval="1.0"/>
           <field name="type">percent</field>
         </record>
         <record id="account_tax_template_p_irpf9" model="account.tax.template">
+          <field name="ref_base_code_id" ref="account_tax_code_template_IRPBI9"/>
           <field name="ref_base_sign" eval="-1.0"/>
           <field name="description">P_IRPF9</field>
           <field name="type_tax_use">purchase</field>
           <field name="account_paid_id" ref="pgc_4751"/>
           <field name="base_sign" eval="1.0"/>
+          <field name="base_code_id" ref="account_tax_code_template_IRPBI9"/>
           <field name="ref_tax_sign" eval="-1.0"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_IRPC9"/>
           <field name="name">Retenciones IRPF 9%</field>
           <field name="account_collected_id" ref="pgc_4751"/>
           <field name="chart_template_id" ref="account_chart_template_common"/>
+          <field name="tax_code_id" ref="account_tax_code_template_IRPC9"/>
           <field name="amount" eval="-0.09"/>
           <field name="tax_sign" eval="1.0"/>
           <field name="type">percent</field>
@@ -1451,15 +1463,19 @@
           <field name="type">percent</field>
         </record>
         <record id="account_tax_template_p_irpf1" model="account.tax.template">
+          <field name="ref_base_code_id" ref="account_tax_code_template_IRPBI1"/>
           <field name="ref_base_sign" eval="-1.0"/>
           <field name="description">P_IRPF1</field>
           <field name="type_tax_use">purchase</field>
           <field name="account_paid_id" ref="pgc_4751"/>
           <field name="base_sign" eval="1.0"/>
+          <field name="base_code_id" ref="account_tax_code_template_IRPBI1"/>
           <field name="ref_tax_sign" eval="-1.0"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_IRPC1"/>
           <field name="name">Retenciones IRPF 1%</field>
           <field name="account_collected_id" ref="pgc_4751"/>
           <field name="chart_template_id" ref="account_chart_template_common"/>
+          <field name="tax_code_id" ref="account_tax_code_template_IRPC1"/>
           <field name="amount" eval="-0.01"/>
           <field name="tax_sign" eval="1.0"/>
           <field name="type">percent</field>
@@ -1471,9 +1487,11 @@
           <field name="account_paid_id" ref="pgc_4751"/>
           <field name="base_sign" eval="1.0"/>
           <field name="ref_tax_sign" eval="-1.0"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_IRPC15"/>
           <field name="name">Retenciones IRPF 15%</field>
           <field name="account_collected_id" ref="pgc_4751"/>
           <field name="chart_template_id" ref="account_chart_template_common"/>
+          <field name="tax_code_id" ref="account_tax_code_template_IRPC15"/>
           <field name="amount" eval="-0.15"/>
           <field name="tax_sign" eval="1.0"/>
           <field name="type">percent</field>
@@ -1607,17 +1625,21 @@
           <field name="type">percent</field>
         </record>
         <record id="account_tax_template_p_irpf20" model="account.tax.template">
+          <field name="ref_base_code_id" ref="account_tax_code_template_IRPBI20"/>
           <field name="ref_base_sign" eval="-1.0"/>
           <field name="description">P_IRPF20</field>
           <field name="type_tax_use">purchase</field>
           <field name="account_paid_id" ref="pgc_4751"/>
           <field name="base_sign" eval="1.0"/>
+          <field name="base_code_id" ref="account_tax_code_template_IRPBI20"/>
           <field name="ref_tax_sign" eval="-1.0"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_IRPC20"/>
           <field name="name">Retenciones IRPF 20%</field>
           <field name="account_collected_id" ref="pgc_4751"/>
           <field name="chart_template_id" ref="account_chart_template_common"/>
           <field name="amount" eval="-0.2"/>
           <field name="tax_sign" eval="1.0"/>
+          <field name="tax_code_id" ref="account_tax_code_template_IRPC20"/>
           <field name="type">percent</field>
         </record>
         <record id="account_tax_template_p_irpf21a" model="account.tax.template">
@@ -1639,31 +1661,39 @@
           <field name="type">percent</field>
         </record>
         <record id="account_tax_template_p_irpf21p" model="account.tax.template">
+          <field name="ref_base_code_id" ref="account_tax_code_template_IRPBI21"/>
           <field name="ref_base_sign" eval="-1.0"/>
           <field name="description">P_IRPF21P</field>
           <field name="type_tax_use">purchase</field>
           <field name="account_paid_id" ref="pgc_4751"/>
           <field name="base_sign" eval="1.0"/>
+          <field name="base_code_id" ref="account_tax_code_template_IRPBI21"/>
           <field name="ref_tax_sign" eval="-1.0"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_IRPC21"/>
           <field name="name">Retenciones IRPF 21%</field>
           <field name="account_collected_id" ref="pgc_4751"/>
           <field name="chart_template_id" ref="account_chart_template_common"/>
           <field name="amount" eval="-0.21"/>
           <field name="tax_sign" eval="1.0"/>
+          <field name="tax_code_id" ref="account_tax_code_template_IRPC21"/>
           <field name="type">percent</field>
         </record>
         <record id="account_tax_template_p_irpf2" model="account.tax.template">
+          <field name="ref_base_code_id" ref="account_tax_code_template_IRPBI2"/>
           <field name="ref_base_sign" eval="-1.0"/>
           <field name="description">P_IRPF2</field>
           <field name="type_tax_use">purchase</field>
           <field name="account_paid_id" ref="pgc_4751"/>
           <field name="base_sign" eval="1.0"/>
+          <field name="base_code_id" ref="account_tax_code_template_IRPBI2"/>
           <field name="ref_tax_sign" eval="-1.0"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_IRPC2"/>
           <field name="name">Retenciones IRPF 2%</field>
           <field name="account_collected_id" ref="pgc_4751"/>
           <field name="chart_template_id" ref="account_chart_template_common"/>
           <field name="amount" eval="-0.02"/>
           <field name="tax_sign" eval="1.0"/>
+          <field name="tax_code_id" ref="account_tax_code_template_IRPC2"/>
           <field name="type">percent</field>
         </record>
         <record id="account_tax_template_s_iva0_isp" model="account.tax.template">

--- a/l10n_es/taxes_common.xml
+++ b/l10n_es/taxes_common.xml
@@ -1609,12 +1609,14 @@
           <field name="type">percent</field>
         </record>
         <record id="account_tax_template_p_irpf21te" model="account.tax.template">
+          <field name="ref_base_code_id" ref="account_tax_code_template_IRPF_RET_PRA_TRA_21_BI_E"/>
           <field name="ref_base_sign" eval="-1.0"/>
           <field name="description">P_IRPF21TE</field>
           <field name="ref_tax_code_id" ref="account_tax_code_template_IRPATCE"/>
           <field name="type_tax_use">purchase</field>
           <field name="account_paid_id" ref="pgc_4751"/>
           <field name="base_sign" eval="1.0"/>
+          <field name="base_code_id" ref="account_tax_code_template_IRPF_RET_PRA_TRA_21_BI_E"/>
           <field name="ref_tax_sign" eval="-1.0"/>
           <field name="name">Retenciones IRPF (Trabajadores) en especie</field>
           <field name="account_collected_id" ref="pgc_4751"/>

--- a/l10n_es/taxes_common.xml
+++ b/l10n_es/taxes_common.xml
@@ -326,7 +326,7 @@
         <record id="account_tax_template_p_irpf21td" model="account.tax.template">
           <field name="ref_base_code_id" ref="account_tax_code_template_IRPATBI"/>
           <field name="ref_base_sign" eval="-1.0"/>
-          <field name="description">P_IRPF21TD</field>
+          <field name="description">P_IRPFTD</field>
           <field name="ref_tax_code_id" ref="account_tax_code_template_IRPATC"/>
           <field name="type_tax_use">purchase</field>
           <field name="account_paid_id" ref="pgc_4751"/>
@@ -1497,17 +1497,21 @@
           <field name="type">percent</field>
         </record>
         <record id="account_tax_template_p_irpf21t" model="account.tax.template">
+          <field name="ref_base_code_id" ref="account_tax_code_template_IRPATBI"/>
           <field name="ref_base_sign" eval="-1.0"/>
-          <field name="description">P_IRPF21T</field>
+          <field name="description">P_IRPFT</field>
           <field name="type_tax_use">purchase</field>
           <field name="account_paid_id" ref="pgc_4751"/>
           <field name="base_sign" eval="1.0"/>
+          <field name="base_code_id" ref="account_tax_code_template_IRPATBI"/>
           <field name="ref_tax_sign" eval="-1.0"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_IRPATC"/>
           <field name="name">Retenciones IRPF 21% (Trabajadores)</field>
           <field name="account_collected_id" ref="pgc_4751"/>
           <field name="chart_template_id" ref="account_chart_template_common"/>
           <field name="amount" eval="-0.21"/>
           <field name="tax_sign" eval="1.0"/>
+          <field name="tax_code_id" ref="account_tax_code_template_IRPATC"/>
           <field name="type">percent</field>
         </record>
         <record id="account_tax_template_p_iva10_sp_in" model="account.tax.template">
@@ -1611,7 +1615,7 @@
         <record id="account_tax_template_p_irpf21te" model="account.tax.template">
           <field name="ref_base_code_id" ref="account_tax_code_template_IRPF_RET_PRA_TRA_21_BI_E"/>
           <field name="ref_base_sign" eval="-1.0"/>
-          <field name="description">P_IRPF21TE</field>
+          <field name="description">P_IRPFTE</field>
           <field name="ref_tax_code_id" ref="account_tax_code_template_IRPATCE"/>
           <field name="type_tax_use">purchase</field>
           <field name="account_paid_id" ref="pgc_4751"/>

--- a/l10n_es/taxes_common.xml
+++ b/l10n_es/taxes_common.xml
@@ -1827,7 +1827,7 @@
           <field name="name">IVA 21% Compra con Inversión del Sujeto Pasivo Nacional (1)</field>
           <field name="description">P_IVA21_ISP_1</field>
           <field name="type_tax_use">purchase</field>
-          <field name="parent_id" ref="account_tax_template_p_iva10_isp"/>
+          <field name="parent_id" ref="account_tax_template_p_iva21_isp"/>
           <field name="type">percent</field>
           <field name="amount" eval="0.21"/>
           <field name="sequence" eval="10"/>
@@ -1847,7 +1847,7 @@
           <field name="name">IVA 21% Compra con Inversión del Sujeto Pasivo Nacional (2)</field>
           <field name="description">P_IVA21_ISP_2</field>
           <field name="type_tax_use">purchase</field>
-          <field name="parent_id" ref="account_tax_template_p_iva10_isp"/>
+          <field name="parent_id" ref="account_tax_template_p_iva21_isp"/>
           <field name="type">percent</field>
           <field name="amount" eval="-0.21"/>
           <field name="sequence" eval="20"/>


### PR DESCRIPTION
Se ha añadido el renombrado de los códigos de impuestos anteriores a los códigos nuevos en el script de migración.
